### PR TITLE
Updated verified version

### DIFF
--- a/src/module.json
+++ b/src/module.json
@@ -2,7 +2,7 @@
 	"id": "token-factions",
 	"title": "Token Factions",
 	"description": "Generate token bases based on token disposition or actor folder color.",
-	"version": "0.3.11",
+	"version": "0.3.12",
 	"authors": [
 		{
 			"name": "Voldemalort",
@@ -64,8 +64,8 @@
 	"styles": [],
 	"compatibility": {
 		"minimum": 10,
-		"verified": 10,
-		"maximum": 10
+		"verified": 11.301,
+		"maximum": 11
 	},
 	"manifestPlusVersion": "1.2.1",
 	"url": "https://github.com/p4535992/foundryvtt-token-factions",


### PR DESCRIPTION
A simple update of the `verified` version was enough to make it work with v11 again. 

Proof:
![image](https://github.com/p4535992/foundryvtt-token-factions/assets/8678523/0155b137-7323-4b97-9849-75665e05cdad)
